### PR TITLE
feat(product): complete phase 4 gold product and ml handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
           dbt run --project-dir dbt
           dbt test --project-dir dbt
 
+      - name: Export versioned Gold product
+        run: finops-export-gold --snapshot-date 2026-04-06
+
       - name: Upload dbt logs on failure
         if: failure()
         uses: actions/upload-artifact@v4
@@ -78,3 +81,4 @@ jobs:
             dbt/logs
             dbt/target
             local_lake/metadata
+            local_lake/gold

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ CAPEX recommendation layer on top of a Bronze, Silver, Gold architecture.
 - Phase 1 implemented: repository foundation, synthetic billing generation, local data lake
 - Phase 2 implemented: DuckDB warehouse, dbt Bronze/Silver/Gold models, finance-facing marts
 - Phase 3 implemented: stronger dbt quality tests, Dagster orchestration, local pipeline metadata, and CI/CD hardening
-- Local validation completed: generator, `pytest`, `dbt seed`, `dbt run`, and `dbt test`
+- Phase 4 implemented: versioned Gold exports and formal ML handoff contract
+- Local validation completed: generator, `pytest`, `dbt seed`, `dbt run`, `dbt test`, and Gold export
 - Current output: each raw billing line is classified into `opex`, `capex_eligible`, `shared_cost_review`, or `unclassified`
 
 ## Why This Repository Exists
@@ -30,8 +31,9 @@ This project is designed to demonstrate:
 
 ## Current Status
 
-Phases 1, 2, and 3 are implemented as the repository foundation, synthetic data
-generation layer, local dbt transformation stack, and quality-orchestrated execution layer.
+Phases 1, 2, 3, and 4 are implemented as the repository foundation, synthetic
+data generation layer, local dbt transformation stack, quality-orchestrated
+execution layer, and versioned export handoff for downstream ML work.
 The project currently provides:
 
 - a documented repository structure and contribution workflow
@@ -44,6 +46,8 @@ The project currently provides:
 - a Dagster job definition for scheduled local execution
 - pipeline run summaries under `local_lake/metadata/pipeline_runs/`
 - GitHub Actions that validate Python quality, SQL linting, and dbt execution
+- versioned Gold exports under `local_lake/gold/ml_handoff/`
+- a downstream ML handoff contract and repository boundary documentation
 
 ## Architecture
 
@@ -57,9 +61,10 @@ flowchart LR
     F --> G[dbt Gold<br/>fct_cost_classification<br/>fct_capex_candidate_costs]
     G --> H[dbt Marts<br/>mart_monthly_finops_summary<br/>mart_capitalization_waterfall]
     H --> I[Pipeline metadata<br/>run_summary.json]
-    H --> J[Finance analytics and ML handoff]
-    K[Dagster job<br/>daily_finops_pipeline] --> A
-    K --> E
+    H --> J[Versioned Gold export<br/>export_manifest.json]
+    J --> K[Finance analytics and ML handoff]
+    L[Dagster job<br/>daily_finops_pipeline] --> A
+    L --> E
 ```
 
 The warehouse model can also be opened in `dbdiagram.io` using
@@ -127,6 +132,7 @@ Current analytical outputs include:
 - Silver standardization and metadata quality signals
 - Gold accounting recommendation facts
 - monthly finance-facing marts
+- versioned Parquet exports for downstream forecasting
 
 ## Quick Start
 
@@ -164,7 +170,13 @@ dbt test --project-dir dbt
 finops-run-pipeline --days 90
 ```
 
-7. Validate a few warehouse outputs:
+7. Export the Gold product independently when needed:
+
+```bash
+finops-export-gold --snapshot-date 2026-04-06
+```
+
+8. Validate a few warehouse outputs:
 
 ```bash
 python -c "import duckdb; con=duckdb.connect('warehouse/finops.duckdb'); print(con.execute('show all tables').fetchdf())"
@@ -176,13 +188,14 @@ For the latest validated local run, both Bronze and Gold materialized the same
 line count, confirming that every raw billing line reached the classification
 layer.
 
-## What You Should Have After Phase 2
+## What You Should Have After Phase 4
 
 - raw Parquet and manifest files under `local_lake/raw/cloud_costs/run_date=.../`
 - local DuckDB warehouse at `warehouse/finops.duckdb`
 - dbt schemas: `analytics_reference`, `analytics_bronze`, `analytics_silver`, `analytics_gold`, and `analytics_marts`
 - classification outputs that separate direct operational spend from CAPEX candidates and review-required shared costs
 - run metadata under `local_lake/metadata/pipeline_runs/run_date=.../run_summary.json`
+- versioned Gold exports under `local_lake/gold/ml_handoff/version=vX.Y.Z/snapshot_date=.../`
 
 ## Repository Highlights
 
@@ -202,6 +215,8 @@ layer.
 - [docs/contributing.md](docs/contributing.md): local development workflow
 - [docs/assistant/project_context.md](docs/assistant/project_context.md): assistant-facing project context
 - [data/contracts/raw_cloud_cost_usage.yml](data/contracts/raw_cloud_cost_usage.yml): raw data contract
+- [data/contracts/gold_ml_handoff.yml](data/contracts/gold_ml_handoff.yml): downstream ML export contract
+- [docs/ml_handoff.md](docs/ml_handoff.md): Project 2 bootstrap and ownership boundary
 - [docs/runbooks/dbt_local_execution.md](docs/runbooks/dbt_local_execution.md): dbt execution guide
 - [docs/runbooks/ci_cd.md](docs/runbooks/ci_cd.md): CI and validation runbook
 - [docs/runbooks/incident_response.md](docs/runbooks/incident_response.md): failure investigation guide

--- a/conf/pipeline.yml
+++ b/conf/pipeline.yml
@@ -4,6 +4,7 @@ storage:
   raw_root: local_lake/raw/cloud_costs
   sample_root: data/sample
   metadata_root: local_lake/metadata/pipeline_runs
+  gold_root: local_lake/gold/ml_handoff
 warehouse:
   path: warehouse/finops.duckdb
 dbt:
@@ -17,3 +18,10 @@ observability:
   freshness_threshold_hours: 24
 orchestration:
   schedule_cron: "0 6 * * *"
+exports:
+  file_format: parquet
+  include_tables:
+    - analytics_gold.fct_cost_classification
+    - analytics_gold.fct_capex_candidate_costs
+    - analytics_marts.mart_monthly_finops_summary
+    - analytics_marts.mart_capitalization_waterfall

--- a/data/contracts/gold_ml_handoff.yml
+++ b/data/contracts/gold_ml_handoff.yml
@@ -1,0 +1,119 @@
+contract_name: gold_ml_handoff
+version: "2026.1"
+owner: analytics-engineering
+status: draft
+description: >
+  Contract for versioned Gold exports consumed by the downstream forecasting and
+  MLOps repository.
+
+freshness:
+  source_relation: analytics_gold.fct_cost_classification
+  freshness_timestamp_column: generated_at_utc
+  max_lag_hours: 24
+  delivery_pattern: snapshot
+
+export_layout:
+  root: local_lake/gold/ml_handoff
+  version_partition: version=vX.Y.Z
+  snapshot_partition: snapshot_date=YYYY-MM-DD
+  manifest_file: export_manifest.json
+  file_format: parquet
+
+tables:
+  - name: analytics_gold.fct_cost_classification
+    grain: one row per billing line item
+    primary_key:
+      - line_item_id
+    purpose: >
+      Canonical labeled dataset for rule-based accounting recommendation and
+      downstream supervised learning experiments.
+    required_columns:
+      - line_item_id
+      - usage_start_time_utc
+      - service
+      - service_family
+      - owner_team
+      - product_line
+      - unblended_cost
+      - blended_cost
+      - classification_status
+      - classification_reason
+      - review_required_flag
+      - policy_version
+    accepted_values:
+      classification_status:
+        - opex
+        - capex_eligible
+        - shared_cost_review
+        - unclassified
+
+  - name: analytics_gold.fct_capex_candidate_costs
+    grain: one row per CAPEX-eligible billing line item
+    primary_key:
+      - line_item_id
+    purpose: >
+      Narrowed export for capitalization-focused modeling, review queues, and
+      amortization analysis.
+    required_columns:
+      - line_item_id
+      - usage_start_time_utc
+      - linked_account_id
+      - service
+      - service_family
+      - owner_team
+      - product_line
+      - initiative_id
+      - initiative_stage
+      - asset_lifecycle
+      - policy_version
+      - amortization_months_default
+      - unblended_cost
+      - blended_cost
+
+  - name: analytics_marts.mart_monthly_finops_summary
+    grain: one row per month, owner team, product line, and classification status
+    primary_key:
+      - billing_month
+      - owner_team
+      - product_line
+      - classification_status
+    purpose: >
+      Primary monthly time-series table for forecasting cost classes and
+      producing downstream training sets.
+    required_columns:
+      - billing_month
+      - owner_team
+      - product_line
+      - classification_status
+      - line_item_count
+      - total_unblended_cost
+      - total_blended_cost
+      - review_cost_total
+      - capex_eligible_cost_total
+      - opex_cost_total
+
+  - name: analytics_marts.mart_capitalization_waterfall
+    grain: one row per month, service family, classification status, and classification reason
+    primary_key:
+      - billing_month
+      - service_family
+      - classification_status
+      - classification_reason
+    purpose: >
+      Explainability-focused export that preserves the reasoning path from raw
+      cost to monthly accounting recommendation totals.
+    required_columns:
+      - billing_month
+      - service_family
+      - classification_status
+      - classification_reason
+      - line_item_count
+      - total_unblended_cost
+      - total_blended_cost
+
+consumer_expectations:
+  null_handling:
+    owner_team: allowed only for incomplete or weakly tagged records
+    initiative_id: allowed for non-capex and shared-cost lines
+  backwards_compatibility: additive changes only between prerelease tags
+  reconciliation_rule: exported row counts must match warehouse row counts

--- a/dbt/models/silver/int_cost_enriched.sql
+++ b/dbt/models/silver/int_cost_enriched.sql
@@ -46,14 +46,18 @@ select
         when usage.tag_quality_status = 'invalid_capitalization_flag' then 'invalid_capitalization_metadata'
         when usage.tag_quality_status = 'missing_critical_tags' then 'missing_critical_tags'
         when usage.shared_service_flag or policy.shared_service_default then 'shared_service'
-        when usage.capitalization_candidate_flag
-             and usage.initiative_stage in ('build', 'implementation')
-             and coalesce(usage.environment, 'prod') in ('prod', 'staging')
-             and coalesce(policy.capex_service_eligible, false) then 'direct_build_cost'
+        when
+            usage.capitalization_candidate_flag
+            and usage.initiative_stage in ('build', 'implementation')
+            and coalesce(usage.environment, 'prod') in ('prod', 'staging')
+            and coalesce(policy.capex_service_eligible, false)
+            then 'direct_build_cost'
         when usage.initiative_stage in ('operate', 'support') then 'operate_support'
         when coalesce(usage.environment, 'prod') in ('sandbox', 'test') then 'non_production'
         else 'other'
     end as accounting_signal
-from {{ ref('stg_cloud_cost_usage') }} as usage
+from
+    {{ ref('stg_cloud_cost_usage') }} as usage
 left join {{ ref('accounting_policy_defaults') }} as policy
-    on usage.service = policy.service
+    on
+        usage.service = policy.service

--- a/dbt/tests/bronze_manifest_row_count_matches.sql
+++ b/dbt/tests/bronze_manifest_row_count_matches.sql
@@ -10,8 +10,11 @@ select
     manifest.batch_id,
     manifest.row_count as manifest_row_count,
     usage_counts.usage_row_count
-from {{ ref('brz_generation_manifest') }} as manifest
+from
+    {{ ref('brz_generation_manifest') }} as manifest
 left join usage_counts
-    on manifest.batch_id = usage_counts.batch_id
-where usage_counts.batch_id is null
-   or manifest.row_count <> usage_counts.usage_row_count
+    on
+        manifest.batch_id = usage_counts.batch_id
+where
+    usage_counts.batch_id is null
+    or manifest.row_count <> usage_counts.usage_row_count

--- a/dbt/tests/gold_capex_candidate_alignment.sql
+++ b/dbt/tests/gold_capex_candidate_alignment.sql
@@ -1,8 +1,11 @@
 select
     candidate.line_item_id,
     classification.classification_status
-from {{ ref('fct_capex_candidate_costs') }} as candidate
+from
+    {{ ref('fct_capex_candidate_costs') }} as candidate
 left join {{ ref('fct_cost_classification') }} as classification
-    on candidate.line_item_id = classification.line_item_id
-where classification.line_item_id is null
-   or classification.classification_status <> 'capex_eligible'
+    on
+        candidate.line_item_id = classification.line_item_id
+where
+    classification.line_item_id is null
+    or classification.classification_status <> 'capex_eligible'

--- a/dbt/tests/marts_monthly_summary_reconciles.sql
+++ b/dbt/tests/marts_monthly_summary_reconciles.sql
@@ -19,12 +19,15 @@ select
     gold_aggregated.expected_line_item_count,
     mart.total_unblended_cost,
     gold_aggregated.expected_total_unblended_cost
-from {{ ref('mart_monthly_finops_summary') }} as mart
+from
+    {{ ref('mart_monthly_finops_summary') }} as mart
 left join gold_aggregated
-    on mart.billing_month = gold_aggregated.billing_month
-   and coalesce(mart.owner_team, '') = coalesce(gold_aggregated.owner_team, '')
-   and coalesce(mart.product_line, '') = coalesce(gold_aggregated.product_line, '')
-   and mart.classification_status = gold_aggregated.classification_status
-where gold_aggregated.billing_month is null
-   or mart.line_item_count <> gold_aggregated.expected_line_item_count
-   or abs(mart.total_unblended_cost - gold_aggregated.expected_total_unblended_cost) > 0.0001
+    on
+        mart.billing_month = gold_aggregated.billing_month
+        and coalesce(mart.owner_team, '') = coalesce(gold_aggregated.owner_team, '')
+        and coalesce(mart.product_line, '') = coalesce(gold_aggregated.product_line, '')
+        and mart.classification_status = gold_aggregated.classification_status
+where
+    gold_aggregated.billing_month is null
+    or mart.line_item_count <> gold_aggregated.expected_line_item_count
+    or abs(mart.total_unblended_cost - gold_aggregated.expected_total_unblended_cost) > 0.0001

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,15 @@ Phase 3 adds operational rigor on top of the analytical stack:
 - run metadata publication for each execution
 - CI jobs that validate Python, SQL, and dbt behavior together
 
+## Phase 4 Scope
+
+Phase 4 turns the analytical warehouse into a versioned product:
+
+- export selected Gold and mart tables as versioned snapshots
+- emit export manifests with schema, row counts, and freshness metadata
+- define the formal downstream contract for ML consumption
+- document the second-repository boundary and bootstrap path
+
 ## Data Flow
 
 ```mermaid
@@ -48,9 +57,10 @@ flowchart LR
     H --> I[dbt Gold]
     I --> J[dbt Marts]
     J --> K[Run metadata and observability]
-    J --> L[Finance consumption and ML handoff]
-    M[Dagster schedule] --> B
-    M --> G
+    J --> L[Versioned Gold export]
+    L --> M[Finance consumption and ML handoff]
+    N[Dagster schedule] --> B
+    N --> G
 ```
 
 ## Warehouse Model
@@ -72,5 +82,4 @@ Core lineage:
 
 ## Next Architectural Step
 
-Phase 4 will publish versioned Gold exports and formalize the ML handoff
-contract on top of the current quality-hardened analytics stack.
+Phase 4 is now the formal delivery boundary for the downstream ML repository.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -70,6 +70,20 @@ ruff check .
 pytest
 ```
 
+## Phase 4 Workflow
+
+Use the versioned export command when you want to publish the latest Gold
+product for downstream ML consumption:
+
+```bash
+finops-export-gold --snapshot-date 2026-04-06
+```
+
+This writes:
+
+- versioned Parquet files under `local_lake/gold/ml_handoff/`
+- an export manifest with schema, row counts, and freshness metadata
+
 ## GitHub Workflow
 
 - issues should be created from the roadmap

--- a/docs/ml_handoff.md
+++ b/docs/ml_handoff.md
@@ -1,0 +1,121 @@
+# ML Handoff
+
+## Purpose
+
+Phase 4 turns the Gold layer into a versioned data product that a second
+repository can consume without reverse-engineering this analytics codebase.
+
+This document defines:
+
+- which exported tables form the downstream interface
+- which forecasting targets are recommended first
+- how the second repository should be bootstrapped
+- where the ownership boundary between repositories sits
+
+## Exported Product
+
+The formal contract lives in
+[`data/contracts/gold_ml_handoff.yml`](../data/contracts/gold_ml_handoff.yml).
+
+Exports are written under:
+
+```text
+local_lake/gold/ml_handoff/
+  version=vX.Y.Z/
+    snapshot_date=YYYY-MM-DD/
+      analytics_gold/
+      analytics_marts/
+      export_manifest.json
+```
+
+The initial exported relations are:
+
+- `analytics_gold.fct_cost_classification`
+- `analytics_gold.fct_capex_candidate_costs`
+- `analytics_marts.mart_monthly_finops_summary`
+- `analytics_marts.mart_capitalization_waterfall`
+
+## Recommended Forecasting Targets
+
+The strongest starting point for Project 2 is monthly forecasting over the marts
+rather than line-item forecasting.
+
+Recommended first targets:
+
+- `total_unblended_cost` by `billing_month`, `owner_team`, and `classification_status`
+- `capex_eligible_cost_total` by `billing_month` and `owner_team`
+- `review_cost_total` to predict upcoming manual review load
+
+Why this is the right starting point:
+
+- the data is already aggregated and reconciled
+- the signal is less sparse than line-item exports
+- it aligns with how finance and FinOps stakeholders consume the output
+
+## Suggested Repository Boundary
+
+This repository owns:
+
+- synthetic raw data generation
+- Bronze, Silver, Gold, and marts logic
+- accounting policy logic and explainability
+- export layout, manifests, and semantic contracts
+
+The second repository should own:
+
+- feature loading from the exported snapshot folders
+- train and validation split policy
+- model architecture and hyperparameter search
+- MLflow experiment tracking
+- model packaging, registry, and deployment
+
+## Suggested Project 2 Bootstrap
+
+Recommended top-level structure:
+
+```text
+finops-cost-forecasting-ml/
+  conf/
+  data_access/
+  features/
+  models/
+  training/
+  evaluation/
+  serving/
+  notebooks/
+  tests/
+  mlruns/ or MLflow backend config
+  README.md
+```
+
+## Initial Modeling Path
+
+Start simple before reaching for deep learning.
+
+Recommended progression:
+
+1. baseline seasonal naive forecast on `mart_monthly_finops_summary`
+2. tree-based regressor or linear model with lag features
+3. PyTorch temporal model only after the baseline is clearly documented
+
+## MLflow Expectations
+
+At minimum, Project 2 should track:
+
+- export version consumed
+- snapshot date consumed
+- target definition
+- feature set version
+- model family
+- train and validation date range
+- error metrics such as MAE, RMSE, and MAPE
+
+## Change Management
+
+Any breaking schema or semantic change to the exported Gold product should be handled by:
+
+1. updating `data/contracts/gold_ml_handoff.yml`
+2. documenting the change in this handoff file
+3. issuing a new prerelease tag for the analytics repository
+
+That keeps the downstream ML repository pinned to an explicit export version.

--- a/docs/runbooks/ci_cd.md
+++ b/docs/runbooks/ci_cd.md
@@ -24,6 +24,7 @@ The repository CI is designed to validate three risk areas on every push and pul
 - import Dagster definitions
 - run `dbt debug`
 - run `dbt seed`, `dbt run`, and `dbt test`
+- run `finops-export-gold` to validate the downstream handoff product
 
 ## Local Parity Commands
 
@@ -32,6 +33,7 @@ From the repository root:
 ```bash
 pre-commit run --all-files
 finops-run-pipeline --days 90
+finops-export-gold --snapshot-date 2026-04-06
 ```
 
 ## Failure Handling

--- a/docs/runbooks/local_execution.md
+++ b/docs/runbooks/local_execution.md
@@ -33,6 +33,20 @@ Expected additional output:
 - `local_lake/metadata/pipeline_runs/run_date=YYYY-MM-DD/run_summary.json`
 - refreshed dbt artifacts under `dbt/target/`
 - validated warehouse contents in `warehouse/finops.duckdb`
+- versioned Gold exports under `local_lake/gold/ml_handoff/version=vX.Y.Z/snapshot_date=YYYY-MM-DD/`
+
+## Export Only
+
+To publish the current warehouse state without rerunning generation and dbt:
+
+```bash
+finops-export-gold --snapshot-date 2026-04-06
+```
+
+Expected output:
+
+- exported Gold and mart tables in Parquet
+- `export_manifest.json` with row counts, schema, and freshness metadata
 
 ## Troubleshooting
 

--- a/orchestration/dagster_project/ops.py
+++ b/orchestration/dagster_project/ops.py
@@ -40,6 +40,8 @@ def run_daily_finops_pipeline_op(context: OpExecutionContext, settings: dict) ->
             "run_date": summary.run_date,
             "batch_id": summary.batch_id or "n/a",
             "metadata_file": summary.metadata_file,
+            "gold_export_manifest": summary.gold_export_manifest_file or "n/a",
+            "gold_export_version": summary.gold_export_version or "n/a",
         }
     )
     return summary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "finops-cost-capitalization-pipeline"
-version = "0.3.0"
+version = "0.4.0"
 description = "Portfolio-grade Analytics Engineering project for FinOps OPEX vs CAPEX recommendation workflows."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -37,6 +37,7 @@ dev = [
 [project.scripts]
 finops-generate = "finops_capex.cli.generate_billing_data:main"
 finops-run-pipeline = "finops_capex.pipeline.cli:main"
+finops-export-gold = "finops_capex.exports.cli:main"
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/scripts/export_gold.py
+++ b/scripts/export_gold.py
@@ -1,0 +1,6 @@
+"""Compatibility wrapper for the packaged Gold export CLI."""
+
+from finops_capex.exports.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/finops_capex/__init__.py
+++ b/src/finops_capex/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/src/finops_capex/exports/__init__.py
+++ b/src/finops_capex/exports/__init__.py
@@ -1,0 +1,5 @@
+"""Gold export helpers for downstream ML handoff."""
+
+from .gold_exporter import GoldExportArtifact, GoldExportSummary, export_gold_tables
+
+__all__ = ["GoldExportArtifact", "GoldExportSummary", "export_gold_tables"]

--- a/src/finops_capex/exports/cli.py
+++ b/src/finops_capex/exports/cli.py
@@ -1,0 +1,46 @@
+"""CLI entrypoint for versioned Gold exports."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from finops_capex.exports.gold_exporter import export_gold_tables
+from finops_capex.pipeline.runtime import load_pipeline_config
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for Gold export execution."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--snapshot-date",
+        required=True,
+        help="Snapshot date used to version the export (YYYY-MM-DD).",
+    )
+    parser.add_argument(
+        "--file-format",
+        choices=["parquet", "csv"],
+        default=None,
+        help="Override the configured export file format.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Export the configured Gold analytical tables and print the manifest path."""
+
+    args = parse_args()
+    pipeline_config = load_pipeline_config(REPOSITORY_ROOT / "conf" / "pipeline.yml")
+    file_format = args.file_format or str(pipeline_config["exports"]["file_format"])
+    summary = export_gold_tables(
+        warehouse_path=REPOSITORY_ROOT / str(pipeline_config["warehouse"]["path"]),
+        export_root=REPOSITORY_ROOT / str(pipeline_config["storage"]["gold_root"]),
+        snapshot_date=args.snapshot_date,
+        relations=list(pipeline_config["exports"]["include_tables"]),
+        file_format=file_format,
+        freshness_threshold_hours=int(pipeline_config["observability"]["freshness_threshold_hours"]),
+    )
+    print(summary.manifest_file)

--- a/src/finops_capex/exports/gold_exporter.py
+++ b/src/finops_capex/exports/gold_exporter.py
@@ -1,0 +1,152 @@
+"""Export versioned Gold analytical tables for downstream ML consumption."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+
+from finops_capex import __version__
+
+
+@dataclass(frozen=True)
+class GoldExportArtifact:
+    """Metadata for one exported analytical table."""
+
+    relation_name: str
+    schema_name: str
+    table_name: str
+    relative_path: str
+    row_count: int
+    columns: list[dict[str, str]]
+
+
+@dataclass(frozen=True)
+class GoldExportSummary:
+    """Summary manifest for a Gold export snapshot."""
+
+    export_version: str
+    snapshot_date: str
+    exported_at: str
+    export_root: str
+    manifest_file: str
+    warehouse_path: str
+    latest_generator_timestamp: str | None
+    freshness_threshold_hours: int
+    freshness_within_threshold: bool | None
+    latest_billing_month: str | None
+    artifacts: list[GoldExportArtifact]
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize the export summary to a JSON-friendly dictionary."""
+
+        payload = asdict(self)
+        payload["artifacts"] = [asdict(artifact) for artifact in self.artifacts]
+        return payload
+
+
+def export_gold_tables(
+    *,
+    warehouse_path: Path,
+    export_root: Path,
+    snapshot_date: str,
+    relations: list[str],
+    file_format: str = "parquet",
+    freshness_threshold_hours: int = 24,
+) -> GoldExportSummary:
+    """Export selected Gold and mart relations to a versioned snapshot folder."""
+
+    if file_format not in {"parquet", "csv"}:
+        raise ValueError("file_format must be either 'parquet' or 'csv'")
+
+    export_version = f"v{__version__}"
+    export_directory = export_root / f"version={export_version}" / f"snapshot_date={snapshot_date}"
+    export_directory.mkdir(parents=True, exist_ok=True)
+
+    connection = duckdb.connect(str(warehouse_path))
+    artifacts: list[GoldExportArtifact] = []
+    exported_at = datetime.now(tz=timezone.utc)
+
+    try:
+        latest_generator_timestamp = connection.execute(
+            """
+            select cast(max(generated_at_utc) as varchar)
+            from analytics_gold.fct_cost_classification
+            """
+        ).fetchone()[0]
+        latest_billing_month = connection.execute(
+            """
+            select cast(max(billing_month) as varchar)
+            from analytics_marts.mart_monthly_finops_summary
+            """
+        ).fetchone()[0]
+
+        freshness_within_threshold = None
+        if latest_generator_timestamp is not None:
+            latest_generated_at = datetime.fromisoformat(latest_generator_timestamp)
+            if latest_generated_at.tzinfo is None:
+                latest_generated_at = latest_generated_at.replace(tzinfo=timezone.utc)
+            freshness_within_threshold = (
+                exported_at - latest_generated_at
+            ).total_seconds() <= freshness_threshold_hours * 3600
+
+        for relation in relations:
+            schema_name, table_name = relation.split(".", maxsplit=1)
+            dataframe = connection.execute(f"select * from {relation}").fetchdf()
+            column_frame = connection.execute(f"describe select * from {relation}").fetchdf()
+            artifact_directory = export_directory / schema_name
+            artifact_directory.mkdir(parents=True, exist_ok=True)
+            artifact_path = artifact_directory / f"{table_name}.{file_format}"
+
+            if file_format == "parquet":
+                dataframe.to_parquet(artifact_path, index=False)
+                exported_row_count = len(pd.read_parquet(artifact_path))
+            else:
+                dataframe.to_csv(artifact_path, index=False)
+                exported_row_count = len(pd.read_csv(artifact_path))
+
+            if exported_row_count != len(dataframe):
+                raise ValueError(
+                    f"Exported row count mismatch for {relation}: "
+                    f"warehouse={len(dataframe)} exported={exported_row_count}"
+                )
+
+            artifacts.append(
+                GoldExportArtifact(
+                    relation_name=relation,
+                    schema_name=schema_name,
+                    table_name=table_name,
+                    relative_path=str(artifact_path.relative_to(export_root)),
+                    row_count=int(len(dataframe)),
+                    columns=[
+                        {
+                            "name": str(row["column_name"]),
+                            "type": str(row["column_type"]),
+                        }
+                        for _, row in column_frame.iterrows()
+                    ],
+                )
+            )
+    finally:
+        connection.close()
+
+    manifest_file = export_directory / "export_manifest.json"
+    summary = GoldExportSummary(
+        export_version=export_version,
+        snapshot_date=snapshot_date,
+        exported_at=exported_at.isoformat(),
+        export_root=str(export_root),
+        manifest_file=str(manifest_file),
+        warehouse_path=str(warehouse_path),
+        latest_generator_timestamp=latest_generator_timestamp,
+        freshness_threshold_hours=freshness_threshold_hours,
+        freshness_within_threshold=freshness_within_threshold,
+        latest_billing_month=latest_billing_month,
+        artifacts=artifacts,
+    )
+    manifest_file.write_text(json.dumps(summary.to_dict(), indent=2), encoding="utf-8")
+    return summary

--- a/src/finops_capex/pipeline/runtime.py
+++ b/src/finops_capex/pipeline/runtime.py
@@ -16,6 +16,7 @@ from typing import Any
 import duckdb
 import yaml
 
+from finops_capex.exports.gold_exporter import GoldExportSummary, export_gold_tables
 from finops_capex.generators import (
     SyntheticBillingGenerator,
     build_generation_runtime_config,
@@ -66,8 +67,12 @@ class PipelineRunSummary:
     metadata_file: str
     warehouse_path: str
     dbt_artifact_path: str
+    gold_export_manifest_file: str | None
+    gold_export_root: str | None
+    gold_export_version: str | None
     stage_results: list[PipelineStageResult]
     warehouse_snapshot: WarehouseQualitySnapshot | None
+    gold_export_summary: GoldExportSummary | None
     error_message: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -140,6 +145,25 @@ def run_command(
         finished_at=finished.isoformat(),
         duration_seconds=round((finished - started).total_seconds(), 3),
         return_code=completed.returncode,
+    )
+
+
+def build_internal_stage_result(
+    *,
+    stage_name: str,
+    command: list[str],
+    started_at: datetime,
+    finished_at: datetime,
+) -> PipelineStageResult:
+    """Build stage metadata for internal Python-only execution steps."""
+
+    return PipelineStageResult(
+        stage_name=stage_name,
+        command=command,
+        started_at=started_at.isoformat(),
+        finished_at=finished_at.isoformat(),
+        duration_seconds=round((finished_at - started_at).total_seconds(), 3),
+        return_code=0,
     )
 
 
@@ -259,6 +283,10 @@ def run_local_pipeline(
         (repository_root / str(pipeline_config["dbt"]["profiles_dir"])).resolve()
     )
     metadata_root = str(pipeline_config["storage"]["metadata_root"])
+    gold_root = repository_root / str(pipeline_config["storage"]["gold_root"])
+    export_relations = list(pipeline_config["exports"]["include_tables"])
+    export_file_format = str(pipeline_config["exports"]["file_format"])
+    freshness_threshold_hours = int(pipeline_config["observability"]["freshness_threshold_hours"])
 
     started_at = datetime.now(tz=timezone.utc)
     stage_results: list[PipelineStageResult] = []
@@ -308,6 +336,24 @@ def run_local_pipeline(
 
         finished_at = datetime.now(tz=timezone.utc)
         snapshot = collect_warehouse_quality_snapshot(warehouse_path)
+        export_started_at = datetime.now(tz=timezone.utc)
+        export_summary = export_gold_tables(
+            warehouse_path=warehouse_path,
+            export_root=gold_root,
+            snapshot_date=manifest.run_date,
+            relations=export_relations,
+            file_format=export_file_format,
+            freshness_threshold_hours=freshness_threshold_hours,
+        )
+        export_finished_at = datetime.now(tz=timezone.utc)
+        stage_results.append(
+            build_internal_stage_result(
+                stage_name="gold_export",
+                command=["internal", "export_gold_tables"],
+                started_at=export_started_at,
+                finished_at=export_finished_at,
+            )
+        )
         metadata_path = build_metadata_path(
             repository_root=repository_root,
             metadata_root=metadata_root,
@@ -326,8 +372,12 @@ def run_local_pipeline(
             metadata_file=str(metadata_path),
             warehouse_path=str(warehouse_path),
             dbt_artifact_path=dbt_artifact_path,
+            gold_export_manifest_file=export_summary.manifest_file,
+            gold_export_root=export_summary.export_root,
+            gold_export_version=export_summary.export_version,
             stage_results=stage_results,
             warehouse_snapshot=snapshot,
+            gold_export_summary=export_summary,
         )
     except subprocess.CalledProcessError as exc:
         finished_at = datetime.now(tz=timezone.utc)
@@ -351,9 +401,45 @@ def run_local_pipeline(
             metadata_file=str(metadata_path),
             warehouse_path=str(warehouse_path),
             dbt_artifact_path=dbt_artifact_path,
+            gold_export_manifest_file=None,
+            gold_export_root=str(gold_root),
+            gold_export_version=None,
             stage_results=stage_results,
             warehouse_snapshot=None,
+            gold_export_summary=None,
             error_message=f"Command failed with exit code {exc.returncode}: {' '.join(exc.cmd)}",
+        )
+        metadata_path.write_text(json.dumps(summary.to_dict(), indent=2), encoding="utf-8")
+        raise
+    except Exception as exc:
+        finished_at = datetime.now(tz=timezone.utc)
+        LOGGER.exception("Pipeline failed with an internal error.")
+        failed_run_date = run_date_override or datetime.now(tz=timezone.utc).date().isoformat()
+        metadata_path = build_metadata_path(
+            repository_root=repository_root,
+            metadata_root=metadata_root,
+            run_date=failed_run_date,
+        )
+        summary = PipelineRunSummary(
+            project_name=str(pipeline_config["project_name"]),
+            status="failed",
+            run_date=failed_run_date,
+            batch_id=None,
+            row_count=None,
+            started_at=started_at.isoformat(),
+            finished_at=finished_at.isoformat(),
+            data_file=None,
+            sample_file=None,
+            metadata_file=str(metadata_path),
+            warehouse_path=str(warehouse_path),
+            dbt_artifact_path=dbt_artifact_path,
+            gold_export_manifest_file=None,
+            gold_export_root=str(gold_root),
+            gold_export_version=None,
+            stage_results=stage_results,
+            warehouse_snapshot=None,
+            gold_export_summary=None,
+            error_message=str(exc),
         )
         metadata_path.write_text(json.dumps(summary.to_dict(), indent=2), encoding="utf-8")
         raise

--- a/tests/unit/test_gold_exporter.py
+++ b/tests/unit/test_gold_exporter.py
@@ -1,0 +1,123 @@
+"""Unit tests for versioned Gold exports."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+
+from finops_capex.exports.gold_exporter import export_gold_tables
+
+
+def build_export_fixture_database(warehouse_path: Path) -> None:
+    """Create minimal warehouse tables required by the Gold exporter."""
+
+    connection = duckdb.connect(str(warehouse_path))
+    connection.execute("create schema analytics_gold")
+    connection.execute("create schema analytics_marts")
+    connection.execute(
+        """
+        create table analytics_gold.fct_cost_classification as
+        select * from (
+            values
+                (
+                    'l1',
+                    timestamp '2026-04-06 10:00:00',
+                    'opex',
+                    10.0,
+                    timestamp '2026-04-06 10:10:00'
+                ),
+                (
+                    'l2',
+                    timestamp '2026-04-06 11:00:00',
+                    'capex_eligible',
+                    15.0,
+                    timestamp '2026-04-06 10:10:00'
+                )
+        ) as t(
+            line_item_id,
+            usage_start_time_utc,
+            classification_status,
+            unblended_cost,
+            generated_at_utc
+        )
+        """
+    )
+    connection.execute(
+        """
+        create table analytics_gold.fct_capex_candidate_costs as
+        select * from (
+            values
+                ('l2', timestamp '2026-04-06 11:00:00', 15.0)
+        ) as t(line_item_id, usage_start_time_utc, unblended_cost)
+        """
+    )
+    connection.execute(
+        """
+        create table analytics_marts.mart_monthly_finops_summary as
+        select * from (
+            values
+                (date '2026-04-01', 'payments-platform', 'payments', 'opex', 1, 10.0),
+                (date '2026-04-01', 'payments-platform', 'payments', 'capex_eligible', 1, 15.0)
+        ) as t(
+            billing_month,
+            owner_team,
+            product_line,
+            classification_status,
+            line_item_count,
+            total_unblended_cost
+        )
+        """
+    )
+    connection.execute(
+        """
+        create table analytics_marts.mart_capitalization_waterfall as
+        select * from (
+            values
+                (date '2026-04-01', 'compute', 'capex_eligible', 'eligible_build_cost', 1, 15.0)
+        ) as t(
+            billing_month,
+            service_family,
+            classification_status,
+            classification_reason,
+            line_item_count,
+            total_unblended_cost
+        )
+        """
+    )
+    connection.close()
+
+
+def test_export_gold_tables_writes_manifest_and_artifacts(tmp_path: Path) -> None:
+    """Gold exports should be versioned, materialized, and accompanied by a manifest."""
+
+    warehouse_path = tmp_path / "warehouse.duckdb"
+    export_root = tmp_path / "gold_exports"
+    build_export_fixture_database(warehouse_path)
+
+    summary = export_gold_tables(
+        warehouse_path=warehouse_path,
+        export_root=export_root,
+        snapshot_date="2026-04-06",
+        relations=[
+            "analytics_gold.fct_cost_classification",
+            "analytics_gold.fct_capex_candidate_costs",
+            "analytics_marts.mart_monthly_finops_summary",
+            "analytics_marts.mart_capitalization_waterfall",
+        ],
+    )
+
+    manifest_path = Path(summary.manifest_file)
+    assert manifest_path.exists()
+    assert summary.export_version == "v0.4.0"
+    assert summary.freshness_within_threshold is True
+    assert len(summary.artifacts) == 4
+
+    manifest_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest_payload["latest_billing_month"] == "2026-04-01"
+
+    artifact_path = export_root / summary.artifacts[0].relative_path
+    assert artifact_path.exists()
+    assert len(pd.read_parquet(artifact_path)) == summary.artifacts[0].row_count

--- a/tests/unit/test_pipeline_runtime.py
+++ b/tests/unit/test_pipeline_runtime.py
@@ -76,6 +76,9 @@ def test_pipeline_run_summary_serialization_keeps_nested_stage_results() -> None
         metadata_file="local_lake/metadata/pipeline_runs/run_date=2026-04-06/run_summary.json",
         warehouse_path="warehouse/finops.duckdb",
         dbt_artifact_path="dbt/target/run_results.json",
+        gold_export_manifest_file="local_lake/gold/ml_handoff/version=v0.4.0/snapshot_date=2026-04-06/export_manifest.json",
+        gold_export_root="local_lake/gold/ml_handoff",
+        gold_export_version="v0.4.0",
         stage_results=[
             PipelineStageResult(
                 stage_name="dbt_run",
@@ -92,10 +95,12 @@ def test_pipeline_run_summary_serialization_keeps_nested_stage_results() -> None
             latest_billing_month="2026-04-01",
             classification_counts={"opex": 7, "capex_eligible": 3},
         ),
+        gold_export_summary=None,
     )
 
     payload = summary.to_dict()
 
     assert payload["stage_results"][0]["stage_name"] == "dbt_run"
     assert payload["warehouse_snapshot"]["gold_row_count"] == 10
+    assert payload["gold_export_version"] == "v0.4.0"
     assert json.loads(json.dumps(payload))["status"] == "success"


### PR DESCRIPTION
## Description

Implements Phase 4 of the roadmap by publishing a versioned Gold analytical
product, defining the downstream ML handoff contract, and documenting the
boundary between this analytics repository and the future forecasting repository.

## Related Issues

- feat(export): publish versioned gold exports with schema and freshness metadata
- docs(contract): define downstream ml handoff schema and semantic contract
- docs(ml): create bridge documentation for forecasting and mlops bootstrap
- chore(mlops): specify second-repository bootstrap structure and release boundary
- docs(portfolio): finalize architecture runbooks and demo narrative

## Changes

- add versioned Gold export module and `finops-export-gold` CLI
- integrate Gold export publication into the local pipeline runtime
- add export manifest with row counts, schema metadata, and freshness fields
- add downstream ML handoff contract in `data/contracts/gold_ml_handoff.yml`
- add ML handoff documentation and second-repository bootstrap guidance
- update README, architecture, contributing guide, and local execution runbook
- update CI to validate the export layer in addition to Python and dbt checks
- align dbt SQL layout with sqlfluff expectations

## Validation

- `python -m pytest`
- `finops-run-pipeline --days 90`
- `finops-export-gold --snapshot-date 2026-04-06`
- `sqlfluff lint dbt/models dbt/tests`
- `ruff check .`

## Checklist

- [x] Gold exports are versioned and documented
- [x] ML handoff contract is defined
- [x] Repository boundary for Project 2 is documented
- [x] CI validates the analytical product export
- [x] No unrelated changes included
