### PR TITLE
docs(test): elevate portfolio docs and harden dbt/pytest validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versioning aligns with [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for the Python package and export contract labels.
+
+## [Unreleased]
+
+### Added
+
+- Pytest integration smoke that runs `dbt seed`, `dbt run`, and `dbt test` against an isolated DuckDB file and a synthetic Parquet batch (see `tests/integration/test_dbt_pipeline_e2e.py`).
+- Optional `FINOPS_DUCKDB_PATH` environment variable in `dbt/profiles.yml` to override the DuckDB file path (default remains `warehouse/finops.duckdb` relative to the repository root when you run dbt from that root).
+- `pythonpath = ["."]` in pytest configuration so `orchestration.*` imports resolve consistently (including Windows).
+
+### Fixed
+
+- Gold exporter unit test no longer asserts a 24-hour freshness window against fixed fixture timestamps (avoids failures when the calendar moves forward).
+
+## [0.4.0] - 2026-04-06
+
+### Summary
+
+- Local-first FinOps pipeline: synthetic billing, Bronze/Silver/Gold dbt models, versioned Gold export for ML handoff, Dagster job definitions, and CI across Python, SQL, and dbt.
+
+### Contracts
+
+- Raw billing shape: [`data/contracts/raw_cloud_cost_usage.yml`](data/contracts/raw_cloud_cost_usage.yml).
+- Gold ML handoff: [`data/contracts/gold_ml_handoff.yml`](data/contracts/gold_ml_handoff.yml).
+
+**Breaking changes** to those YAML contracts or to exported table lists in `conf/pipeline.yml` / `finops_capex` should bump the package version and be called out under `## [x.y.z]` with a `### Changed` or `### Removed` subsection.

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ That distinction is important:
 
 So this is not a mixed real-plus-fake billing repository. It is a synthetic-source project with a real Analytics Engineering and FinOps workflow built on top of it.
 
+### Security and credentials
+
+Do not commit cloud provider credentials, private billing extracts, or production connection strings. This project is designed to run on **synthetic** data; keep real FinOps datasets out of git and use secret stores in any shared environment.
+
 That is intentional and portfolio-appropriate:
 
 - no confidential billing data is required,
@@ -249,6 +253,14 @@ Explicitly out of scope for this repository:
 
 Those are intentionally reserved for the downstream ML repository described in [docs/ml_handoff.md](docs/ml_handoff.md).
 
+## Roadmap at a glance
+
+The full phased plan lives in [ROADMAP.md](ROADMAP.md). Status in short:
+
+- **Done:** synthetic billing generator, local lake layout, dbt Bronze/Silver/Gold/marts, accounting recommendation logic, pipeline metadata, versioned Gold export, Dagster job for local scheduling, CI (Python, SQLFluff, dbt, export smoke).
+- **In progress / next:** tighter `dagster-dbt` integration for asset-aware runs (see ROADMAP orchestration notes).
+- **Deferred:** training, serving, and production cloud deployment (downstream ML repo).
+
 ## Repository Walkthrough
 
 Core implementation:
@@ -273,6 +285,20 @@ Project documentation:
 
 ## Quick Start
 
+### From zero to a green run (clean machine)
+
+1. **Clone** the repository and open a terminal at the repo root.
+2. **Python 3.10+**: create and activate a virtual environment (`python -m venv .venv` then activate per your OS).
+3. **Install** dependencies: `pip install -e ".[dev]"` (pulls `dbt-core`, `dbt-duckdb`, Dagster, and dev tools).
+4. **Generate** a synthetic batch: `finops-generate --days 90 --output-format parquet` (writes under `local_lake/` and samples under `data/sample/`).
+5. **Run** the full pipeline: `finops-run-pipeline --days 90` (dbt + metadata + export steps as configured in `conf/pipeline.yml`).
+6. **Verify** with tests: `pytest` (includes a marked **integration** test that runs `dbt seed` / `run` / `test` against an isolated DuckDB file; allow ~30s for that case).
+7. **Optional — Dagster UI:** `dagster dev -m orchestration.dagster_project.definitions` from the repo root to explore the packaged job and schedules.
+
+If anything fails, see [docs/runbooks/local_execution.md](docs/runbooks/local_execution.md) and [docs/runbooks/ci_cd.md](docs/runbooks/ci_cd.md).
+
+### Common commands
+
 Install dependencies:
 
 ```bash
@@ -291,6 +317,24 @@ Run tests:
 pytest
 ```
 
+Run only fast tests (skip dbt integration):
+
+```bash
+pytest -m "not integration"
+```
+
+Run the integration dbt smoke only:
+
+```bash
+pytest -m integration
+```
+
+Measure Python coverage (optional):
+
+```bash
+pytest --cov=finops_capex --cov-report=term-missing
+```
+
 Run the full local pipeline:
 
 ```bash
@@ -302,6 +346,23 @@ Export the current Gold product:
 ```bash
 finops-export-gold --snapshot-date 2026-04-06
 ```
+
+## CLI versus Dagster
+
+- **`finops-run-pipeline`** (and the individual CLIs) are the straightforward way to run or debug the pipeline from a shell, reproduce CI locally, and script one-off runs. Configuration comes from `conf/pipeline.yml` and `conf/` profiles.
+- **Dagster** (`orchestration/dagster_project/`) packages the same stages as a scheduled **job** (`daily_finops_pipeline`) for local-first automation, observability in the Dagster UI, and a clear path to richer orchestration later.
+- **Next step (see [ROADMAP.md](ROADMAP.md)):** wiring **`dagster-dbt`** so dbt models appear as Dagster assets is planned; today the job invokes the existing Python/dbt runtime rather than a full asset graph.
+
+## Testing and coverage
+
+Unit tests cover the generator, pipeline runtime, Gold exporter, and Dagster definitions load. The **integration** test `tests/integration/test_dbt_pipeline_e2e.py` lands a small synthetic Parquet batch in a temporary directory, points dbt vars at those globs, sets `FINOPS_DUCKDB_PATH` to an isolated DuckDB file, and runs `dbt seed`, `dbt run`, and `dbt test` — closely mirroring the assumptions validated in CI.
+
+Use `pytest --cov=finops_capex` when you want a coverage report before a release or portfolio refresh.
+
+## Contracts and releases
+
+- **YAML data contracts:** [data/contracts/raw_cloud_cost_usage.yml](data/contracts/raw_cloud_cost_usage.yml) (raw billing) and [data/contracts/gold_ml_handoff.yml](data/contracts/gold_ml_handoff.yml) (ML handoff).
+- **Version history and breaking changes:** [CHANGELOG.md](CHANGELOG.md). Bump the package version in `pyproject.toml` when you change export shapes, contract fields, or default table lists in `conf/pipeline.yml` in a way that downstream consumers must react to.
 
 For detailed execution steps, see [docs/runbooks/local_execution.md](docs/runbooks/local_execution.md).
 

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -3,6 +3,6 @@ finops_capex:
   outputs:
     dev:
       type: duckdb
-      path: warehouse/finops.duckdb
+      path: "{{ env_var('FINOPS_DUCKDB_PATH', 'warehouse/finops.duckdb') }}"
       threads: 4
       schema: analytics

--- a/docs/runbooks/local_execution.md
+++ b/docs/runbooks/local_execution.md
@@ -69,3 +69,13 @@ If running dbt manually, point the profile directory to the repository-local con
 ```bash
 export DBT_PROFILES_DIR="$(pwd)/dbt"
 ```
+
+### Optional: separate DuckDB file path
+
+By default the dev target uses `warehouse/finops.duckdb` (relative to the repository root when dbt is invoked from that root). To use another file — for example in automated tests or a second local experiment — set:
+
+```bash
+export FINOPS_DUCKDB_PATH="/absolute/path/to/your.duckdb"
+```
+
+On Windows PowerShell, use `set FINOPS_DUCKDB_PATH=C:\path\to\your.duckdb` before running dbt.

--- a/orchestration/dagster_project/ops.py
+++ b/orchestration/dagster_project/ops.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from dagster import OpExecutionContext, Out, op
+from dagster import Out, op
 
 from finops_capex.pipeline.runtime import (
     PipelineRunSummary,
@@ -20,7 +20,7 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 
 
 @op(out=Out(dict))
-def load_pipeline_settings_op(context: OpExecutionContext) -> dict:
+def load_pipeline_settings_op(context) -> dict:
     """Load the shared pipeline YAML used by local execution and Dagster."""
 
     del context
@@ -28,7 +28,7 @@ def load_pipeline_settings_op(context: OpExecutionContext) -> dict:
 
 
 @op(out=Out(PipelineRunSummary))
-def run_daily_finops_pipeline_op(context: OpExecutionContext, settings: dict) -> PipelineRunSummary:
+def run_daily_finops_pipeline_op(context, settings: dict) -> PipelineRunSummary:
     """Run the full local-first pipeline and emit summary metadata."""
 
     summary = run_local_pipeline(
@@ -49,7 +49,7 @@ def run_daily_finops_pipeline_op(context: OpExecutionContext, settings: dict) ->
 
 
 @op
-def emit_pipeline_health_op(context: OpExecutionContext, summary: PipelineRunSummary) -> None:
+def emit_pipeline_health_op(context, summary: PipelineRunSummary) -> None:
     """Publish a concise health snapshot for the latest successful pipeline run."""
 
     warehouse_snapshot = summary.warehouse_snapshot or collect_warehouse_quality_snapshot(
@@ -66,7 +66,7 @@ def emit_pipeline_health_op(context: OpExecutionContext, summary: PipelineRunSum
 
 
 @op(out=Out(str))
-def validate_dbt_environment_op(context: OpExecutionContext, settings: dict) -> str:
+def validate_dbt_environment_op(context, settings: dict) -> str:
     """Validate that the dbt runtime can be resolved before a scheduled run."""
 
     del context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,11 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 addopts = "-ra"
+markers = [
+  "integration: exercises the dbt CLI against an isolated DuckDB file (slower than unit tests)",
+]
 
 [tool.ruff]
 line-length = 100

--- a/tests/integration/test_dbt_pipeline_e2e.py
+++ b/tests/integration/test_dbt_pipeline_e2e.py
@@ -1,0 +1,94 @@
+"""End-to-end dbt smoke: isolated DuckDB + synthetic parquet (mirrors CI assumptions)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from finops_capex.generators import GenerationConfig, SyntheticBillingGenerator
+from finops_capex.ingestion.lake_writer import write_raw_billing_batch
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def isolated_dbt_env(tmp_path: Path) -> dict[str, str]:
+    """Point DuckDB at a fresh file under tmp_path; keep profiles in-repo."""
+
+    warehouse_dir = tmp_path / "warehouse"
+    warehouse_dir.mkdir(parents=True, exist_ok=True)
+    db_file = warehouse_dir / "finops.duckdb"
+
+    env = os.environ.copy()
+    env["DBT_PROFILES_DIR"] = str((REPOSITORY_ROOT / "dbt").resolve())
+    env["FINOPS_DUCKDB_PATH"] = db_file.as_posix()
+    return env
+
+
+def _run_dbt(
+    *args: str,
+    cwd: Path,
+    env: dict[str, str],
+    vars_payload: str,
+) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        "dbt",
+        *args,
+        "--project-dir",
+        "dbt",
+        "--vars",
+        vars_payload,
+    ]
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.integration
+def test_dbt_seed_run_test_against_synthetic_parquet(
+    tmp_path: Path,
+    isolated_dbt_env: dict[str, str],
+) -> None:
+    """Land a minimal parquet batch, then run the same dbt stages as CI."""
+
+    generator = SyntheticBillingGenerator(GenerationConfig(days=14, seed=42))
+    dataframe = generator.generate_dataframe()
+    write_raw_billing_batch(
+        dataframe=dataframe,
+        repository_root=tmp_path,
+        run_date="2026-04-06",
+        output_format="parquet",
+        sample_size=10,
+    )
+
+    raw_partition = tmp_path / "local_lake/raw/cloud_costs/run_date=*"
+    raw_glob = (raw_partition / "cloud_cost_usage.parquet").as_posix()
+    manifest_glob = (raw_partition / "manifest.json").as_posix()
+    vars_payload = json.dumps(
+        {
+            "raw_cloud_cost_glob": raw_glob,
+            "raw_manifest_glob": manifest_glob,
+        }
+    )
+
+    for stage in ("seed", "run", "test"):
+        result = _run_dbt(
+            stage,
+            cwd=REPOSITORY_ROOT,
+            env=isolated_dbt_env,
+            vars_payload=vars_payload,
+        )
+        if result.returncode != 0:
+            pytest.fail(
+                f"dbt {stage} failed (exit {result.returncode})\n"
+                f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            )

--- a/tests/unit/test_gold_exporter.py
+++ b/tests/unit/test_gold_exporter.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import json
+from datetime import timezone
 from pathlib import Path
 
 import duckdb
 import pandas as pd
-
-from datetime import timezone
 
 from finops_capex.exports.gold_exporter import _parse_warehouse_timestamp, export_gold_tables
 
@@ -109,6 +108,8 @@ def test_export_gold_tables_writes_manifest_and_artifacts(tmp_path: Path) -> Non
             "analytics_marts.mart_monthly_finops_summary",
             "analytics_marts.mart_capitalization_waterfall",
         ],
+        # Fixture timestamps are fixed; widen threshold so the test does not depend on wall clock.
+        freshness_threshold_hours=24 * 365,
     )
 
     manifest_path = Path(summary.manifest_file)


### PR DESCRIPTION
## Summary
- Documentação de portfólio (README, CHANGELOG, runbook) e testes mais próximos do fluxo de CI (dbt isolado + pytest).

## Validation
- `ruff check .`
- `pytest`
- (se aplicável) `pytest -m integration` / pipeline CI verde nos dois jobs

## Notes
- `FINOPS_DUCKDB_PATH` documentado; padrão de warehouse inalterado sem a variável.